### PR TITLE
Security Fix for Command Injection - huntr.dev

### DIFF
--- a/lib/configUtil.js
+++ b/lib/configUtil.js
@@ -86,7 +86,7 @@ module.exports = {
       }
 
       // https://developer.mozilla.org/en-US/docs/Mozilla/Command_Line_Options
-      childProcess.execSync(firefoxPath + ' -CreateProfile "firefox_hii_pref ' + dir + '"');
+      childProcess.execFileSync(firefoxPath, ['-CreateProfile', 'firefox_hii_pref', dir]);
       fs.writeFileSync(prefsPath, prefs.join('\n'));
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,8 +71,7 @@ module.exports = {
         var commandOptions = configUtil[browser](dataDir, url, browserPath, proxyURL, pacFileURL, bypassList);
 
         return new Promise(function (resolve, reject) {
-          var cmdStr = browserPath + ' ' + commandOptions;
-          childProcess.exec(cmdStr, {maxBuffer: 50000 * 1024}, function (err) {
+          childProcess.execFile(browserPath, commandOptions.split(' '), {maxBuffer: 50000 * 1024}, function (err) {
             if (err) {
               reject(err);
             } else {
@@ -109,7 +108,8 @@ module.exports = {
         switch (platform) {
           case 'darwin':
             cmd = 'mdfind "kMDItemCFBundleIdentifier==' + info.darwin + '" | head -1';
-            result = childProcess.execSync(cmd).toString().trim();
+            cmd = cmd.split(' ');
+            result = childProcess.execFileSync(cmd[0], cmd.slice(1)).toString().trim();
             result += '/Contents/MacOS/' + info.appName;
             result = result.replace(/\s/g, '\\ ');
             break;
@@ -125,8 +125,8 @@ module.exports = {
             HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\firefox.exe
             (默认)    REG_SZ    C:\Program Files\Mozilla Firefox\firefox.exe
             */
-
-            result = childProcess.execSync(cmd).toString().trim();
+            cmd = cmd.split(' ')
+            result = childProcess.execFileSync(cmd[0], cmd.slice(1)).toString().trim();
             result = result.split('\n').pop().split(/\s+REG_SZ\s+/).pop();
             result = result.replace(/^"|"$/g, '');
             break;


### PR DESCRIPTION
https://huntr.dev/users/Mik317 has fixed the Command Injection vulnerability 🔨. Mik317 has been awarded $25 for fixing the vulnerability through the huntr bug bounty program 💵. Think you could fix a vulnerability like this?
           
Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/open-browser/pull/2
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/op-browser/1/README.md

### User Comments:

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-op-browser

### ⚙️ Description *

The `op-browser` module was vulnerable against `RCE` since `user supplied inputs` were formatted insecurely inside the `command` which was then executed

### 💻 Technical Description *

I replaced all the occurrences of `exec` and `execSync` with `execFile` and `execFileSync` :smile:

### 🐛 Proof of Concept (PoC) *

1. Create the PoC file:

```js
// poc.js
var root = require("op-browser");
root.open('chrome','& touch Song','','');
```
1. `node poc.js`
2. The `Song` file is created

### 🔥 Proof of Fix (PoF) *

Same steps with fixed version doesn't create the `Song` file

### 👍 User Acceptance Testing (UAT)

Should be all ok 👍 